### PR TITLE
Replace periodic timer redraw with event-driven USB callback

### DIFF
--- a/usb/usb_toypad.c
+++ b/usb/usb_toypad.c
@@ -5,6 +5,7 @@
 #include "usb.h"
 #include "usb_hid.h"
 
+#include "../ldtoypad.h"
 #include "../views/EmulateToyPad_scene.h"
 #include "../tea.h"
 #include "../burtle.h"
@@ -189,6 +190,12 @@ void hid_in_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
     UNUSED(dev);
 
     // nothing to do here
+}
+
+static void usb_redraw_callback(void* context, uint32_t arg) {
+    UNUSED(context);
+    UNUSED(arg);
+    view_dispatcher_send_custom_event(get_view_dispatcher(), 0);
 }
 
 void hid_out_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
@@ -423,6 +430,9 @@ void hid_out_callback(usbd_device* dev, uint8_t event, uint8_t ep) {
 
     // Send the response
     usbd_ep_write(dev, HID_EP_IN, res_buf, sizeof(res_buf));
+
+    // Defer screen redraw to timer thread context (not safe to call view_dispatcher from ISR)
+    furi_timer_pending_callback(usb_redraw_callback, NULL, 0);
 }
 
 /* Configure endpoints */

--- a/views/EmulateToyPad_scene.c
+++ b/views/EmulateToyPad_scene.c
@@ -26,8 +26,6 @@ FuriHalUsbInterface* usb_mode_prev = NULL;
 
 struct LDToyPadSceneEmulate {
     View* view;
-
-    FuriTimer* timer; // Timer for redrawing the screen
 };
 
 // The selected pad on the toypad
@@ -309,11 +307,6 @@ static void ldtoypad_scene_emulate_draw_render_callback(Canvas* canvas, void* co
 
         // Give dolphin some xp for connecting the toypad
         dolphin_deed(DolphinDeedPluginStart);
-
-        if(toypadscene_instance->timer != NULL) {
-            furi_timer_stop(toypadscene_instance->timer);
-            furi_timer_start(toypadscene_instance->timer, furi_ms_to_ticks(5000));
-        }
     } else if(model->connected) {
         model->connection_status = "USB Connected";
     } else if(!model->connected) {
@@ -516,26 +509,6 @@ static uint32_t ldtoypad_scene_emulate_navigation_submenu_callback(void* context
     return ViewSubmenu;
 }
 
-void ldtoypad_scene_emulate_view_game_timer_callback(void* context) {
-    UNUSED(context);
-    view_dispatcher_send_custom_event(get_view_dispatcher(), 0);
-}
-
-void ldtoypad_scene_emulate_enter_callback(void* context) {
-    uint32_t period = furi_ms_to_ticks(200);
-    LDToyPadSceneEmulate* app = (LDToyPadSceneEmulate*)context;
-    furi_assert(app->timer == NULL);
-    app->timer = furi_timer_alloc(
-        ldtoypad_scene_emulate_view_game_timer_callback, FuriTimerTypePeriodic, app);
-    furi_timer_start(app->timer, period);
-}
-
-void ldtoypad_scene_emulate_exit_callback(void* context) {
-    LDToyPadSceneEmulate* app = (LDToyPadSceneEmulate*)context;
-    furi_timer_stop(app->timer);
-    furi_timer_free(app->timer);
-    app->timer = NULL;
-}
 
 static bool ldtoypad_scene_emulate_custom_event_callback(uint32_t event, void* context) {
     LDToyPadSceneEmulate* scene = (LDToyPadSceneEmulate*)context;
@@ -582,9 +555,6 @@ LDToyPadSceneEmulate* ldtoypad_scene_emulate_alloc(LDToyPadApp* new_app) {
     view_set_input_callback(instance->view, ldtoypad_scene_emulate_input_callback);
 
     view_set_previous_callback(instance->view, ldtoypad_scene_emulate_navigation_submenu_callback);
-
-    view_set_enter_callback(instance->view, ldtoypad_scene_emulate_enter_callback);
-    view_set_exit_callback(instance->view, ldtoypad_scene_emulate_exit_callback);
 
     view_set_custom_callback(instance->view, ldtoypad_scene_emulate_custom_event_callback);
 


### PR DESCRIPTION
Remove the periodic FuriTimer that redrew the screen every 200 milliseconds and instead trigger a redraw directly from the USB HID out callback using furi_timer_pending_callback. This approach avoids unnecessary redraws and safely defers the view update out of ISR context.